### PR TITLE
Fix z-index and options color on select

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -15,6 +15,7 @@ import {
   Themes,
   ThemeProps,
   SANS_SERIF,
+  Z_INDEX_BASE,
   Z_INDEX_PREVIEW_CONTENT
 } from '../../style';
 import { Module } from '../../interfaces';
@@ -55,7 +56,8 @@ const Select = glamorous.select<ThemeProps>(
     appearance: 'none',
     fontSize: '1.3rem',
     paddingRight: '1.3rem',
-    outline: 'none'
+    outline: 'none',
+    zIndex: Z_INDEX_BASE
   },
   SANS_SERIF,
   ({ theme }) => ({

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -103,7 +103,11 @@ const IconContainer = glamorous.div({
   justifyContent: 'flex-end'
 });
 
-const Option = glamorous.option();
+const Option = (withTheme as any)(
+  glamorous.option<ThemeProps>(({ theme }) => ({
+    color: theme.light.text
+  }))
+);
 
 interface SelectData {
   library: string;


### PR DESCRIPTION
This PR fixes the z-index of the select and makes sure to always use dark text color for select options.

Closes #80.
Closes #81.